### PR TITLE
refactor(compile-games): rename binary outputs

### DIFF
--- a/.github/workflows/compile-games.yml
+++ b/.github/workflows/compile-games.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           name: linux-programs
           path: | 
-              **/*-linux-program.out
+              **/linux-x86.out
 
   compile-games-windows:
     runs-on: windows-latest
@@ -112,7 +112,7 @@ jobs:
         with:
           name: windows-programs
           path: | 
-              **/*-windows-program.exe
+              **/windows-x86.exe
 
   compile-games-arm:
     runs-on: ubuntu-latest
@@ -147,7 +147,7 @@ jobs:
         with:
           name: arm-programs
           path: | 
-            **/*-arm-program.out
+            **/linux-arm.out
 
   push-games:
     runs-on: ubuntu-latest

--- a/.github/workflows/compile-games.yml
+++ b/.github/workflows/compile-games.yml
@@ -68,7 +68,7 @@ jobs:
           read GAME_DIR <<< "${{ needs.get-game-directory.outputs.game-directory }}"
           for dir in ${GAME_DIR[@]}
           do                               
-            ./compile-game.sh $GITHUB_WORKSPACE/$dir linux-program.out
+            ./compile-game.sh $GITHUB_WORKSPACE/$dir linux-x86.out
           done  
 
       - uses: actions/upload-artifact@v3
@@ -104,7 +104,7 @@ jobs:
               read GAME_DIR <<< "${{ needs.get-game-directory.outputs.game-directory }}"
               for dir in ${GAME_DIR[@]}
               do                               
-                ./compile-game.sh $GITHUB_WORKSPACE/$dir windows-program.exe
+                ./compile-game.sh $GITHUB_WORKSPACE/$dir windows-x86.exe
               done                                  
               
 
@@ -140,7 +140,7 @@ jobs:
             skm linux install                                 
             for dir in ${GAME_DIR[@]}
             do           
-              ./compile-game.sh $dir arm-program.out
+              ./compile-game.sh $dir linux-arm.out
             done            
 
       - uses: actions/upload-artifact@v3

--- a/compile-game.sh
+++ b/compile-game.sh
@@ -1,5 +1,5 @@
 GAME_DIR=$1
-BINARY_SUFFIX=$2             
+BINARY_NAME=$2             
 
 cd $GAME_DIR
 
@@ -30,15 +30,15 @@ echo Compiling game $game_name...
 # If command is empty
 if [[ -z "$command" ]]; then
 	echo "No compile command found, using default"
-	skm g++ program.cpp -o ${game_name}-$BINARY_SUFFIX
+	skm g++ program.cpp -o $BINARY_NAME
 else
 	# If command starts with skm
 	if [[ $command == "skm"* ]]; then
 	echo Appending output flag and name/loc 
-	command+=" -o ${game_name}-$BINARY_SUFFIX"
+	command+=" -o $BINARY_NAME"
 	else
 	echo Assuming usage of makefile, appending output name/loc 
-	command+=" ${game_name}-$BINARY_SUFFIX"
+	command+=" $BINARY_NAME"
 	fi
 	echo "Running compile command: $command"
 	eval $command

--- a/games/Example-Game/program.cpp
+++ b/games/Example-Game/program.cpp
@@ -5,7 +5,7 @@ int main()
 	open_window("Example Game",600,400);
 	while(!quit_requested() && !key_typed(ESCAPE_KEY))
 	{
-		clear_screen(COLOR_GREEN);
+		clear_screen(COLOR_YELLOW);
 		refresh_screen(60);
 		process_events();
 	}


### PR DESCRIPTION
Addressing [Arcade-Machine Issue](https://github.com/thoth-tech/arcade-machine/pull/62#issuecomment-1247414433)
Rename binary outputs to 
+ Windows - windows-x86.exe
+ Linux (x86) - linux-x86.out
+ Linux (ARM) - linux-arm.out