### PR TITLE
Below the Surface - Prevent Player 2 from Dieing when going off screen & Adjusting ladder Behavior

### DIFF
--- a/games/BelowTheSurface/block.h
+++ b/games/BelowTheSurface/block.h
@@ -10,7 +10,6 @@ class Block
         point_2d position;
         drawing_options opts;
         double top;
-        double left;
         string type;
         rectangle hitbox;
         rectangle special_hitbox;
@@ -27,7 +26,6 @@ class Block
             this->position = position;
             this->opts = option_defaults();
             this->top = position.y - bitmap_cell_height(image);
-            this->left = position.x;
             make_hitbox();
         };
 
@@ -44,11 +42,6 @@ class Block
         float get_top()
         {
             return this->top;
-        };
-
-        float get_left()
-        {
-            return this->left;
         };
 
         point_2d get_pos()
@@ -149,7 +142,7 @@ class SolidBlock : public Block
         {
             string collision = "None";
             double dx = (one.x + one.width / 2) - (this->hitbox.x + this->hitbox.width / 2);
-            double dy = (one.y + one.height / 2) - (this->hitbox.y + this->hitbox.height/ 2);
+            double dy = (one.y + one.height / 2) - (this->hitbox.y + this->hitbox.height / 2);
             double width = (one.width + this->hitbox.width) / 2;
             double height = (one.height + this->hitbox.height) / 2;
             double crossWidth = width * dy;
@@ -278,35 +271,14 @@ class Ladder : public Block
 
         string test_collision(rectangle one) override
         {
-            //A straight copy and paste from the StoneBlock class
-            string collision = "None";
-            double dx = (one.x + one.width / 2) - (this->hitbox.x + this->hitbox.width / 2);
-            double dy = (one.y + one.height / 2) - (this->hitbox.y + this->hitbox.height/ 2);
-            double width = (one.width + this->hitbox.width) / 2;
-            double height = (one.height + this->hitbox.height + 6) / 2;
-            double crossWidth = width * dy;
-            double crossHeight = height * dx;
-            if (abs(dx) <= width && abs(dy) <= height)
-            {
-                if (crossWidth >= crossHeight)
-                {
-                    if (crossWidth + 100 > (-crossHeight))
-                        collision = "Bottom";
-                    else
-                        collision = "Left";
-                }
-                else
-                {
-                    // Gave a bias to top collision to avoid right edge stopping player during movement
-                    if (crossWidth - 200 > -(crossHeight))
-                        collision = "Right";
-                    else
-                        collision = "Top";
-                }
-            }
+            bool x_overlaps = (rectangle_left(one) < rectangle_right(this->hitbox)) && (rectangle_right(one) > rectangle_left(this->hitbox));
+            bool y_overlaps = (rectangle_top(one) < rectangle_bottom(this->hitbox)) && (rectangle_bottom(one) > rectangle_top(this->hitbox) - 15);
+            bool collision = x_overlaps && y_overlaps;
 
-            return collision;
-            
+            if (collision)
+                return "Collision";
+            else
+                return "None";
         };
 };
 
@@ -527,11 +499,9 @@ class DoorBlock : public Block
         string test_collision(rectangle one) override
         {
             bool x_overlaps = (rectangle_left(one) < rectangle_right(this->hitbox)) && (rectangle_right(one) > rectangle_left(this->hitbox));
-            bool y_overlaps = (rectangle_top(one) < rectangle_bottom(this->hitbox)) && (rectangle_bottom(one) > rectangle_top(this->hitbox)-200);
+            bool y_overlaps = (rectangle_top(one) < rectangle_bottom(this->hitbox)) && (rectangle_bottom(one) > rectangle_top(this->hitbox));
             bool collision = x_overlaps && y_overlaps;
 
-            // if((rectangle_top(one) < rectangle_bottom(this->hitbox)) && (rectangle_bottom(one) > rectangle_top(this->hitbox))){
-            //     return "TopLadder";
             if (collision)
                 return "Collision";
             else

--- a/games/BelowTheSurface/block.h
+++ b/games/BelowTheSurface/block.h
@@ -10,6 +10,7 @@ class Block
         point_2d position;
         drawing_options opts;
         double top;
+        double left;
         string type;
         rectangle hitbox;
         rectangle special_hitbox;
@@ -26,6 +27,7 @@ class Block
             this->position = position;
             this->opts = option_defaults();
             this->top = position.y - bitmap_cell_height(image);
+            this->left = position.x;
             make_hitbox();
         };
 
@@ -42,6 +44,11 @@ class Block
         float get_top()
         {
             return this->top;
+        };
+
+        float get_left()
+        {
+            return this->left;
         };
 
         point_2d get_pos()
@@ -142,7 +149,7 @@ class SolidBlock : public Block
         {
             string collision = "None";
             double dx = (one.x + one.width / 2) - (this->hitbox.x + this->hitbox.width / 2);
-            double dy = (one.y + one.height / 2) - (this->hitbox.y + this->hitbox.height / 2);
+            double dy = (one.y + one.height / 2) - (this->hitbox.y + this->hitbox.height/ 2);
             double width = (one.width + this->hitbox.width) / 2;
             double height = (one.height + this->hitbox.height) / 2;
             double crossWidth = width * dy;
@@ -271,14 +278,35 @@ class Ladder : public Block
 
         string test_collision(rectangle one) override
         {
-            bool x_overlaps = (rectangle_left(one) < rectangle_right(this->hitbox)) && (rectangle_right(one) > rectangle_left(this->hitbox));
-            bool y_overlaps = (rectangle_top(one) < rectangle_bottom(this->hitbox)) && (rectangle_bottom(one) > rectangle_top(this->hitbox) - 15);
-            bool collision = x_overlaps && y_overlaps;
+            //A straight copy and paste from the StoneBlock class
+            string collision = "None";
+            double dx = (one.x + one.width / 2) - (this->hitbox.x + this->hitbox.width / 2);
+            double dy = (one.y + one.height / 2) - (this->hitbox.y + this->hitbox.height/ 2);
+            double width = (one.width + this->hitbox.width) / 2;
+            double height = (one.height + this->hitbox.height + 6) / 2;
+            double crossWidth = width * dy;
+            double crossHeight = height * dx;
+            if (abs(dx) <= width && abs(dy) <= height)
+            {
+                if (crossWidth >= crossHeight)
+                {
+                    if (crossWidth + 100 > (-crossHeight))
+                        collision = "Bottom";
+                    else
+                        collision = "Left";
+                }
+                else
+                {
+                    // Gave a bias to top collision to avoid right edge stopping player during movement
+                    if (crossWidth - 200 > -(crossHeight))
+                        collision = "Right";
+                    else
+                        collision = "Top";
+                }
+            }
 
-            if (collision)
-                return "Collision";
-            else
-                return "None";
+            return collision;
+            
         };
 };
 
@@ -499,9 +527,11 @@ class DoorBlock : public Block
         string test_collision(rectangle one) override
         {
             bool x_overlaps = (rectangle_left(one) < rectangle_right(this->hitbox)) && (rectangle_right(one) > rectangle_left(this->hitbox));
-            bool y_overlaps = (rectangle_top(one) < rectangle_bottom(this->hitbox)) && (rectangle_bottom(one) > rectangle_top(this->hitbox));
+            bool y_overlaps = (rectangle_top(one) < rectangle_bottom(this->hitbox)) && (rectangle_bottom(one) > rectangle_top(this->hitbox)-200);
             bool collision = x_overlaps && y_overlaps;
 
+            // if((rectangle_top(one) < rectangle_bottom(this->hitbox)) && (rectangle_bottom(one) > rectangle_top(this->hitbox))){
+            //     return "TopLadder";
             if (collision)
                 return "Collision";
             else

--- a/games/BelowTheSurface/camera.h
+++ b/games/BelowTheSurface/camera.h
@@ -1,7 +1,12 @@
 #include "splashkit.h"
 #include "player.h"
 #include <memory>
+#include <vector>
+#include <iostream>
+
 #pragma once
+
+using namespace std;
 
 class Camera
 {
@@ -10,13 +15,13 @@ class Camera
         double y_border_top = 0;
         double x_border_right;
         double y_border_bottom;
-        std::shared_ptr<Player> player;
+        vector<shared_ptr<Player>> players;
 
     public:
-        Camera(std::shared_ptr<Player> player, int tile_size, int map_height, int map_width)
+        // Camera(std::shared_ptr<Player> player, int tile_size, int map_height, int map_width)
+        Camera(vector<shared_ptr<Player>> players, int tile_size, int map_height, int map_width)
         {
-            this->player = player;
-
+            this->players = players;
             this->x_border_right = tile_size * map_width;
             this->y_border_bottom = -(tile_size * map_height);
         };
@@ -26,7 +31,28 @@ class Camera
 
         void update()
         {
-            center_camera_on(this->player->get_player_sprite(), 0, 0);
+            double mid_player_x = 0;
+            double mid_player_y = 0;
+
+            for(int i = 0; i < players.size(); i++)
+            {
+                if(players[i]->get_player_sprite())
+                {
+                    mid_player_x += (sprite_position(players[i]->get_player_sprite()).x);
+                    mid_player_y += (sprite_position(players[i]->get_player_sprite()).y);
+                }
+            }
+
+            mid_player_x = mid_player_x / players.size();
+            mid_player_y = mid_player_y / players.size();
+
+            point_2d mid_player = {mid_player_x, mid_player_y};
+
+            double sc_x = mid_player.x + - (screen_width() / 2);
+            double sc_y = mid_player.y + - (screen_height() / 2);
+
+            move_camera_to(sc_x, sc_y);
+
 
             if(camera_x() < x_border_left)
                 set_camera_x(x_border_left);

--- a/games/BelowTheSurface/collision.h
+++ b/games/BelowTheSurface/collision.h
@@ -163,10 +163,11 @@ void check_ladder_collisions(vector<vector<shared_ptr<Ladder>>> ladders, unorder
 
                 x_condi = (sprite_x(level_players[k]->get_player_sprite()) > left_side - 32 && sprite_x(level_players[k]->get_player_sprite()) < left_side + 32);
                 for(int m = 0; m < lad_pos_top[left_side].size(); m++){
-                    if(sprite_y(level_players[k]->get_player_sprite()) < (lad_pos_top[left_side][m] + 1)){
+                    if(sprite_y(level_players[k]->get_player_sprite()) <= (lad_pos_top[left_side][m] + 2) && sprite_y(level_players[k]->get_player_sprite()) >= (lad_pos_top[left_side][m] - 1)){
                         y_condi = true;
+                        break;
                     }else{
-                        y_condi = false;
+                        continue;
                     }
                 }
 
@@ -174,6 +175,9 @@ void check_ladder_collisions(vector<vector<shared_ptr<Ladder>>> ladders, unorder
 
                 // If player touch the top of the ladder in the exact x position
                 if(collision == "Top" && (x_condi && y_condi)){
+                    if(key_typed(level_players[k]->input.attack_key))
+                        level_players[k]->set_player_won(true);
+
                     if(key_down(level_players[k]->input.crouch_key)){ //Drop the player down when crouch key is pressed
                         level_players[k]->set_on_floor(false);
                     }else{

--- a/games/BelowTheSurface/collision.h
+++ b/games/BelowTheSurface/collision.h
@@ -4,6 +4,7 @@
 #include "block.h"
 #include <memory>
 #include <vector>
+#include <unordered_map>
 
 #pragma once
 
@@ -62,7 +63,7 @@ void check_solid_block_collisions(vector<vector<shared_ptr<Block>>> solid_blocks
                 }
                 else if (collision == "Bottom")
                 {
-                    if (level_players[k]->is_on_floor())
+                    if (level_players[k]->is_on_floor() &&!(level_players[k]->is_on_ladder()))
                         break;
 
                     if (!sound_effect_playing("HeadHit"))
@@ -120,8 +121,12 @@ void check_solid_block_collisions(vector<vector<shared_ptr<Block>>> solid_blocks
                 break;
         }
 
-        if (collision == "None")
+        if (collision == "None" && level_players[k]->is_on_ladder()==false){
             level_players[k]->set_on_floor(false);
+        }
+            
+        // if (collision == "None")
+        //     level_players[k]->set_on_floor(false);
     }
 }
 
@@ -142,38 +147,65 @@ void check_door_block_collisions(shared_ptr<DoorBlock> door, vector<shared_ptr<P
     }
 }
 
-void check_ladder_collisions(vector<vector<shared_ptr<Ladder>>> ladders, vector<shared_ptr<Player>> level_players)
+void check_ladder_collisions(vector<vector<shared_ptr<Ladder>>> ladders, unordered_map<double, vector<double>> lad_pos_top, vector<shared_ptr<Player>> level_players)
 {
+    double left_side, top_side;
     for (int k = 0; k < level_players.size(); k++)
     {
         string collision = "None";
+        bool y_condi = false,x_condi;
         for (int j = 0; j < ladders.size(); j++)
         {
             for (int i = 0; i < ladders[j].size(); i++)
             {
-                if (!rect_on_screen(ladders[j][i]->get_block_hitbox()))
-                    continue;
+                left_side = ladders[j][i]->get_left();
+                top_side = ladders[j][i]->get_top();
 
-                if(level_players[k]->get_state_type() == "Dying")
-                    continue;
+                x_condi = (sprite_x(level_players[k]->get_player_sprite()) > left_side - 32 && sprite_x(level_players[k]->get_player_sprite()) < left_side + 32);
+                for(int m = 0; m < lad_pos_top[left_side].size(); m++){
+                    if(sprite_y(level_players[k]->get_player_sprite()) < (lad_pos_top[left_side][m] + 1)){
+                        y_condi = true;
+                    }else{
+                        y_condi = false;
+                    }
+                }
 
                 collision = ladders[j][i]->test_collision(level_players[k]->get_player_hitbox());
 
-                if (collision != "None" && (key_typed(level_players[k]->input.jump_key) || key_typed(level_players[k]->input.crouch_key)))
+                // If player touch the top of the ladder in the exact x position
+                if(collision == "Top" && (x_condi && y_condi)){
+                    if(key_down(level_players[k]->input.crouch_key)){ //Drop the player down when crouch key is pressed
+                        level_players[k]->set_on_floor(false);
+                    }else{
+                        level_players[k]->set_on_floor(true);
+                        level_players[k]->set_on_ladder(true);
+
+                        //this prevent the player stepping on random ladder block that's not the top of the ladder
+                        if(level_players[k]->get_state_type() != "JumpFall" || level_players[k]->get_state_type() != "JumpRise"){
+                            sprite_set_y(level_players[k]->get_player_sprite(), top_side - 1);
+                        }
+                    }
+                    break;
+                }else if (!(collision == "None" || collision == "Top") && (key_typed(level_players[k]->input.jump_key) || key_typed(level_players[k]->input.crouch_key)))
                 {
                     level_players[k]->set_on_ladder(true);
-                    sprite_set_y(level_players[k]->get_player_sprite(), sprite_y(level_players[k]->get_player_sprite()) - 1);
+                    sprite_set_y(level_players[k]->get_player_sprite(), sprite_y(level_players[k]->get_player_sprite()) - 10);
+                    level_players[k]->set_player_dx(0);
                     level_players[k]->change_state(new ClimbState, "Climb");
+                    level_players[k]->set_on_floor(false);
                     break;
                 }
                 else if (collision != "None" && level_players[k]->get_state_type() == "Climb")
+                {
                     break;
+                }
             }
+        };
 
-            if (collision == "None")
-            {
-                level_players[k]->set_on_ladder(false);
-            }
+        if (collision == "None")
+        {
+            level_players[k]->set_on_ladder(false);
+            // level_players[k]->set_on_floor(false);
         }
     }
 }

--- a/games/BelowTheSurface/level.h
+++ b/games/BelowTheSurface/level.h
@@ -12,7 +12,6 @@
 #include "levelparts.h"
 #include <memory>
 #include <vector>
-#include <unordered_map>
 
 #pragma once
 
@@ -48,7 +47,6 @@ class Level
         string level_name = "";
         music level_music;
         bitmap pre_level_image;
-        unordered_map<double, vector<double>> lad_pos_top; 
 
     public:
         bool is_player1_out_of_lives = false;
@@ -56,7 +54,6 @@ class Level
 
         bool is_player2_out_of_lives = false;
         bool player2_complete = true;
-        
 
         Level(vector<CellSheet> cell_sheets, int tile_size, int players)
         {
@@ -74,40 +71,10 @@ class Level
 
         ~Level(){};
 
-        void scan_ladder(){
-            double left_side, top_side;
-            int size;
-            unordered_map<double, vector<double>> copy_lad;
-            // create a copy to save the y position of the ladders
-
-            // Find the lad_pos_top x values of the ladders array
-            for(int i{0}; i < this->ladders.size(); i++){
-                for(int j{0}; j < this->ladders[i].size(); j++){
-
-                    left_side = this->ladders[i][j]->get_left();
-                    top_side = this->ladders[i][j]->get_top();
-                    size = this->lad_pos_top[left_side].size();
-
-                    // if the left side of the ladder is not in the copy_lad
-                    if(copy_lad[left_side].size() == 0){
-                        this->lad_pos_top[left_side].push_back(top_side);
-                        copy_lad[left_side].push_back(top_side);
-                    // Check if there's ladder block below
-                    }else if(top_side - copy_lad[left_side][size - 1] == 64){
-                        copy_lad[left_side][size - 1] = top_side;
-                    }else{
-                    // if there's no ladder block below, add it to the lad_pos_top
-                        this->lad_pos_top[left_side].push_back(top_side);
-                        copy_lad[left_side].push_back(top_side);
-                    }
-                }
-            }
-        }
-
         void make_level()
         {
             this->door = make_level_door(files[0], this->tile_size, cell_sheets[5].cells);
-            
+
             if (players == 2)
             {
                 for (int i = 1; i < players + 1; i++)
@@ -180,8 +147,6 @@ class Level
 
                 this->level_enemies = make_layer_enemies(this->level_enemies, file, this->tile_size, this->level_players);
             }
-
-            scan_ladder();
 
             shared_ptr<HUD> hud(new HUD(level_players));
             this->level_hud = hud;
@@ -379,7 +344,7 @@ class Level
 
         void check_collisions()
         {
-            check_ladder_collisions(ladders, lad_pos_top, level_players);
+            check_ladder_collisions(ladders, level_players);
             check_solid_block_collisions(solid_blocks, level_players);
 
             // check for player to pick up a holdable pipe

--- a/games/BelowTheSurface/level.h
+++ b/games/BelowTheSurface/level.h
@@ -12,6 +12,7 @@
 #include "levelparts.h"
 #include <memory>
 #include <vector>
+#include <unordered_map>
 
 #pragma once
 
@@ -47,6 +48,7 @@ class Level
         string level_name = "";
         music level_music;
         bitmap pre_level_image;
+        unordered_map<double, vector<double>> lad_pos_top; 
 
     public:
         bool is_player1_out_of_lives = false;
@@ -54,6 +56,7 @@ class Level
 
         bool is_player2_out_of_lives = false;
         bool player2_complete = true;
+        
 
         Level(vector<CellSheet> cell_sheets, int tile_size, int players)
         {
@@ -71,10 +74,40 @@ class Level
 
         ~Level(){};
 
+        void scan_ladder(){
+            double left_side, top_side;
+            int size;
+            unordered_map<double, vector<double>> copy_lad;
+            // create a copy to save the y position of the ladders
+
+            // Find the lad_pos_top x values of the ladders array
+            for(int i{0}; i < this->ladders.size(); i++){
+                for(int j{0}; j < this->ladders[i].size(); j++){
+
+                    left_side = this->ladders[i][j]->get_left();
+                    top_side = this->ladders[i][j]->get_top();
+                    size = this->lad_pos_top[left_side].size();
+
+                    // if the left side of the ladder is not in the copy_lad
+                    if(copy_lad[left_side].size() == 0){
+                        this->lad_pos_top[left_side].push_back(top_side);
+                        copy_lad[left_side].push_back(top_side);
+                    // Check if there's ladder block below
+                    }else if(top_side - copy_lad[left_side][size - 1] == 64){
+                        copy_lad[left_side][size - 1] = top_side;
+                    }else{
+                    // if there's no ladder block below, add it to the lad_pos_top
+                        this->lad_pos_top[left_side].push_back(top_side);
+                        copy_lad[left_side].push_back(top_side);
+                    }
+                }
+            }
+        }
+
         void make_level()
         {
             this->door = make_level_door(files[0], this->tile_size, cell_sheets[5].cells);
-
+            
             if (players == 2)
             {
                 for (int i = 1; i < players + 1; i++)
@@ -147,6 +180,8 @@ class Level
 
                 this->level_enemies = make_layer_enemies(this->level_enemies, file, this->tile_size, this->level_players);
             }
+
+            scan_ladder();
 
             shared_ptr<HUD> hud(new HUD(level_players));
             this->level_hud = hud;
@@ -344,7 +379,7 @@ class Level
 
         void check_collisions()
         {
-            check_ladder_collisions(ladders, level_players);
+            check_ladder_collisions(ladders, lad_pos_top, level_players);
             check_solid_block_collisions(solid_blocks, level_players);
 
             // check for player to pick up a holdable pipe

--- a/games/BelowTheSurface/levelparts.h
+++ b/games/BelowTheSurface/levelparts.h
@@ -210,13 +210,14 @@ shared_ptr<DoorBlock> make_level_door(string file, int tile_size, bitmap cell_sh
     return door;
 }
 
-shared_ptr<Camera> make_level_camera(shared_ptr<Player> player, string file, int tile_size)
+// shared_ptr<Camera> make_level_camera(shared_ptr<Player> player, string file, int tile_size)
+shared_ptr<Camera> make_level_camera(vector<shared_ptr<Player>> players, string file, int tile_size)
 {
     LevelOjectsMap map(file, tile_size);
     int map_width = map.get_map_width();
     int map_height = map.get_map_height();
 
-    shared_ptr<Camera> camera(new Camera(player, tile_size, map_height, map_width));
+    shared_ptr<Camera> camera(new Camera(players, tile_size, map_height, map_width));
 
     return camera;
 }

--- a/games/BelowTheSurface/player.h
+++ b/games/BelowTheSurface/player.h
@@ -97,8 +97,9 @@ class Player
             this->state->update();
         };
 
+
         void get_input()
-        {
+        {   
             this->state->get_input();
         };
 
@@ -185,6 +186,7 @@ class Player
         void set_player_dx(float value)
         {
             sprite_set_dx(this->player_sprite, value);
+            // sprite_set_dx(this->player_sprite, value);
         };
 
         // Returns true or false if the player is dead or not.
@@ -221,6 +223,11 @@ class Player
         point_2d get_player_position()
         {
             return this->position;
+        };
+
+        void set_player_position(point_2d new_position)
+        {
+            this->position = new_position;
         };
 
         // Returns true or false if the player is holding a pipe or not.
@@ -551,6 +558,7 @@ void IdleState::get_input()
 void RunState::update()
 {
     sprite player_sprite = this->player->get_player_sprite();
+
     if (!run_once)
     {
         if (dx == 0)
@@ -586,6 +594,7 @@ void RunState::update()
     player_draw_pipe(player);
 
     sprite_update_routine_continuous(this->player->get_player_sprite());
+    
 }
 
 void RunState::get_input()


### PR DESCRIPTION
# Description
## Prevent Player 2 from Dieing when going off screen
According to this code:
```cpp
   if(!point_on_screen(to_screen(player_pos)) && level_players[i]->get_state_type() != "Dying")
   {
      if(level_players[i]->get_state_type() != "Spawn")
        this->level_players[i]->change_state(new DyingState, "Dying");
  }
```
If player 2 if out of the screen of player 1 then player 2 will surely die, making it impossible to progress the game. In addition to the problem, in camera.h it uses `center_camera_on()` method, which only support 1 type of sprite.

To fix, all the above issue, first we need to make sure that if any players hits the edge of the screen, then both player can't move forward (reason why it's 0.2 and not 0 it's because the players can still move a bit when it's goes to 0):
```cpp
  if (level_players[i]->get_state_type() != "Dying") {
    double speed_1  = (this->level_players[0]->is_facing_left()) ? 0.2 : -0.2;
    double speed_2  = (this->level_players[1]->is_facing_left()) ? 0.2 : -0.2;

    if(to_screen_x(player_pos.x) <= 35 || to_screen_x(player_pos.x) >= screen_width() - 35){
        this->level_players[0]->set_player_dx(speed_1);
        this->level_players[1]->set_player_dx(speed_2);
    }
}
```
next we accept player parameter as an array in the `camera.h` file:
```cpp
Camera(vector<shared_ptr<Player>> players, int  tile_size, int  map_height, int  map_width)
```
now we want to have the camera to track between players, to do this we add both position then divide them by 2 and use `move_camera_to()` method to set the position of the camera.

```cpp
double  mid_player_x = 0;
double  mid_player_y = 0;

for(int  i = 0; i < players.size(); i++){
	if(players[i]->get_player_sprite()){
		mid_player_x += (sprite_position(players[i]->get_player_sprite()).x);
		mid_player_y += (sprite_position(players[i]->get_player_sprite()).y);
	}
}

mid_player_x = mid_player_x / players.size();
mid_player_y = mid_player_y / players.size();

point_2d  mid_player = {mid_player_x, mid_player_y};

double  sc_x = mid_player.x + - (screen_width() / 2);
double  sc_y = mid_player.y + - (screen_height() / 2);

move_camera_to(sc_x, sc_y);
```
Finally we want the player to respawn to the other player when they are dead. To do this we just going to set the spawn point as the other player location when the player is dead. For singleplayer the spawn point will be at the start as default:
```cpp
//If player is dying, set their position to the other player as a spawn point

if(level_players[i]->get_state_type() ==  "Dying"){
	if(level_players.size() > 1){
		if(this->level_players[i]->get_player_id() == 2){
			this->level_players[i]->set_player_position(sprite_position(level_players[0]->get_player_sprite()));
		}else{
			this->level_players[i]->set_player_position(sprite_position(level_players[1]->get_player_sprite()));

		}

	}

}
```
**Video demo:**

https://github.com/thoth-tech/arcade-games/assets/128771372/f65eb1cd-400b-48b8-b81c-000eeb2591f1

## Adjusting ladder Behavior

At the current version of the Below The Surface, Player fells through the ladder when reaches the top. In this pull request, it provide fixes for that issue. 

- `block.h`: the ladder class's collision test, detecting both horizontal and vertical directions, no split up individually, which is an issue when trying to implement the detecting for top layer only.
```cpp
bool  x_overlaps = (rectangle_left(one) < rectangle_right(this->hitbox)) && (rectangle_right(one) > rectangle_left(this->hitbox));
bool  y_overlaps = (rectangle_top(one) < rectangle_bottom(this->hitbox)) && (rectangle_bottom(one) > rectangle_top(this->hitbox));
bool  collision = x_overlaps && y_overlaps;

if (collision)
	return  "Collision";
else
	return  "None";
```

 - `collision.h`: currently nothing to performed for collision "Top". In need implementation.
### Solution
 - `block.h`: just copy paste the same collision test from the Solid Block
 - `collision.h`:
		 - Create an unordered map (Hash map) to store the y value at the top of the ladder block. It was done by detected the x value of the ladder
		 - Checking if the ladder got a "Top" collision while using the unordered map to find the ladder block we want to stand on
		 - Performing huge amount of bug fixes after the implementation :3
	


**Video demo:**

https://github.com/thoth-tech/arcade-games/assets/128771372/1e2547ec-d70a-4a36-bed9-713054c21844


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Separate left, right, top, button collision type for ladders
- [x] Make collision accept the top collision so the player can stand on the ladder
- [x] Added a new lib call unordered_map to help find the unique number

# How Has This Been Tested?

- [x] Tested with Windows 10
- [x] Testing in both singleplayer and multiplayer
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Requested a review from seniors on the Pull Request

