### PR TITLE
Update .gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-*/bin/debug/*
-*/obj/debug/*
-*/bin/Debug/*
+**/[Bb]in/
+**/[Oo]bj/


### PR DESCRIPTION
# Description

When using the tooling recommended in the SplashKit installation guide, some new files are generated by a combination of VS Code and the recommended extensions (at least for me in a Windows environment using VS Code and the recommended extensions), particularly relating to Sky Surge.

Most of these files (e.g., those in `/obj/*`) are only relevant to the machine which they're generated on, and so should be excluded from the repo (much like some existing debugging files already are).

Exclusions in .gitignore have now been changed to blanket rules for all `obj` and `bin` folders / sub-folders, based on the project's structure and recommendations such as those from GitHub (albeit for Visual Studio) and gitignore.io (for C# and C++ in Visual Studio Code). This will automatically pick up all the sub-folders which contain games (including new additions) and automatically ignore those build folders, including case sensitivity for `Obj` vs `obj` and `Bin` vs `bin`.

I've categorized this under documentation since that seems to better fits it as a "meta", non-code change.

## Type of change

- [x] Documentation (update or new)

## How Has This Been Tested?

N/A

## Testing Checklist

N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas (N/A)
- [ ] I have made corresponding changes to the documentation (N/A)
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
