### PR TITLE
All games - ignore locally compiled exes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 # .vscode/
 .DS_Store
 games/**/*.exe
+in-progress-games/**/*.exe

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/[Oo]bj/
 # .vscode/
 .DS_Store
+games/**/*.exe


### PR DESCRIPTION
# Description

To test games we need to compile games. However, these files aren't useful to the repo because any compiled game will be platform-specific. This PR adds `exe` files in the `games` and `in-progress-games` folders to gitignore to prevent this issue without affecting e.g. `compiled-games`.

Based on conversations and experience during T1, I think this fixes what we want without collateral damage to the automated builds.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I re-compiled Below The Surface to check whether the resulting `exe` file would be ignored, which it was.

## Testing Checklist

N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I'll notify my team when the PR is ready to review