### PR TITLE
PR REDO: Below The Surface - Fix broken player attack

### DIFF
--- a/games/BelowTheSurface/collision.h
+++ b/games/BelowTheSurface/collision.h
@@ -365,7 +365,15 @@ void check_enemy_player_collisions(vector<shared_ptr<Enemy>> level_enemies, vect
 
                 if (attack_success)
                 {
-                    level_enemies[i]->take_damage(1);
+                    if (level_enemies[i]->get_hp() <= 0)
+                    {
+                        play_sound_effect("EnemyDead");
+                        level_enemies[i]->set_dead(true);
+                    }
+                    else if (level_enemies[i]->get_vulnerable())
+                    {
+                        level_enemies[i]->take_damage(1); // By 1 hp.
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
This is a manual re-implementation of #202 to enable merge conflict resolution - please see there for PR info.

I made one additional non-functional change, combining a nested `else -> if` into a single `else if`.