### PR TITLE
PR REDO: Below The Surface - Visual fix for backstory screen

### DIFF
--- a/games/BelowTheSurface/screen.h
+++ b/games/BelowTheSurface/screen.h
@@ -1061,6 +1061,7 @@ void BackstoryScreen::update()
     font screen_font = font_named("DefaultFont");
     int font_size = 80;
     color font_color = COLOR_WHITE_SMOKE;
+    point_2d pt = screen_center();
 
     if (!music_playing())
     {
@@ -1068,7 +1069,7 @@ void BackstoryScreen::update()
         set_music_volume(0.2f);
     }
 
-    if (screen_timer(8, "BackstoryTimer"))
+    if (screen_timer(45, "BackstoryTimer"))
     {
         clear_screen(COLOR_BLACK);
         current++;
@@ -1077,9 +1078,9 @@ void BackstoryScreen::update()
     
     if(current == 0)
     {
-        point_2d pt = screen_center();
         draw_bitmap(this->name(), 0, 0, option_to_screen());
-        draw_text("Backstory", font_color, screen_font, font_size, pt.x- text_width("Backstory", screen_font, font_size)/2, (pt.y - text_height("Backstory", screen_font, font_size)/2) - 200, option_to_screen());
+        draw_text("Backstory", font_color, screen_font, font_size, pt.x- text_width("Backstory", screen_font, font_size)/2, (pt.y - text_height("Backstory", screen_font, font_size)/2) - 150, option_to_screen());
+        draw_text("Press key to continue. . .", font_color, screen_font, 20, pt.x- text_width("Press key to continue. . .", screen_font, 20)/2, (pt.y - text_height("Press key to continue. . .", screen_font, 20)/2) + 180, option_to_screen());
     }
     else if (current > max_screens - 1)
         this->screen->change_state(new MenuScreen, "Menu");
@@ -1092,6 +1093,8 @@ void BackstoryScreen::update()
         if(current > max_screens - 1)
             this->screen->change_state(new MenuScreen, "Menu");
     }
+    
+    draw_text("Press key to continue. . .", font_color, screen_font, 20, pt.x- text_width("Press key to continue. . .", screen_font, 20)/2, (pt.y - text_height("Press key to continue. . .", screen_font, 20)/2) + 180, option_to_screen());
 }
 
 void play_sounds()


### PR DESCRIPTION
This is a manual re-implementation of #204 to enable merge conflict resolution - please see there for PR info.

I've made one additional non-functional change by adding a blank line immediately above the final draw_text function call.