### PR TITLE
fix: resolve C++ build errors in games

### DIFF
--- a/games/BelowTheSurface/behaviour.h
+++ b/games/BelowTheSurface/behaviour.h
@@ -190,8 +190,9 @@ class SnakeBehaviour : public Behaviour
                 if(change_direction)
                     continue;
                     
-                point_2d player_center = to_screen(center_point(level_players[i]->get_player_sprite()));
-                point_2d enemy_center = to_screen(center_point(enemy_sprite));
+                sprite ps_i = level_players[i]->get_player_sprite();
+                point_2d player_center = to_screen(point_at(sprite_x(ps_i) + sprite_width(ps_i) / 2.0, sprite_y(ps_i) + sprite_height(ps_i) / 2.0));
+                point_2d enemy_center = to_screen(point_at(sprite_x(enemy_sprite) + sprite_width(enemy_sprite) / 2.0, sprite_y(enemy_sprite) + sprite_height(enemy_sprite) / 2.0));
 
                 double dist = player_center.x - enemy_center.x;
 
@@ -313,8 +314,9 @@ class WaterRatBehaviour : public Behaviour
 
         void face_player()
         {
-            point_2d player_center = to_screen(center_point(level_players[0]->get_player_sprite()));
-            point_2d enemy_center = to_screen(center_point(enemy_sprite));
+            sprite ps_0 = level_players[0]->get_player_sprite();
+            point_2d player_center = to_screen(point_at(sprite_x(ps_0) + sprite_width(ps_0) / 2.0, sprite_y(ps_0) + sprite_height(ps_0) / 2.0));
+            point_2d enemy_center = to_screen(point_at(sprite_x(enemy_sprite) + sprite_width(enemy_sprite) / 2.0, sprite_y(enemy_sprite) + sprite_height(enemy_sprite) / 2.0));
 
             if(enemy_center.x < player_center.x)
                 facing_left = true;

--- a/games/BelowTheSurface/player.h
+++ b/games/BelowTheSurface/player.h
@@ -484,7 +484,8 @@ void player_draw_pipe(Player *player)
 {
     if(player->with_pipe())
     {
-        point_2d position = center_point(player->get_player_sprite());
+        sprite ps = player->get_player_sprite();
+        point_2d position = { sprite_x(ps) + sprite_width(ps) / 2.0, sprite_y(ps) + sprite_height(ps) / 2.0 };
         bitmap pipe = player->get_held_pipe()->get_bitmap();
         drawing_options opts = option_defaults();
         opts.draw_cell = player->get_held_pipe()->get_cell();

--- a/games/HomemadePong/program.cpp
+++ b/games/HomemadePong/program.cpp
@@ -108,8 +108,8 @@ int main()
         controls_p1(player_1);
         controls_p2(player_2);
 
-        draw_text(to_string(score_1), COLOR_ANTIQUE_WHITE, "roboto", 40, (SCREEN_WIDTH / 2) - 50, 20);
-        draw_text(to_string(score_2), COLOR_ANTIQUE_WHITE, "roboto", 40, (SCREEN_WIDTH / 2) + 50, 20);
+        draw_text(std::to_string(score_1), COLOR_ANTIQUE_WHITE, "roboto", 40, (SCREEN_WIDTH / 2) - 50, 20);
+        draw_text(std::to_string(score_2), COLOR_ANTIQUE_WHITE, "roboto", 40, (SCREEN_WIDTH / 2) + 50, 20);
 
         if(sprite_x(ball.ball_sprite) <= 0)
         { 

--- a/games/Pingpong/game.cpp
+++ b/games/Pingpong/game.cpp
@@ -140,8 +140,8 @@ void check_ball_out_of_map(game_data &game)
     // Draw the scores on the screen
     if (game.screen == 3)
     {
-        draw_text(to_string(game.player1.score), COLOR_RED, "font1", 60, 5, 200, option_to_screen());
-        draw_text(to_string(game.player2.score), COLOR_BLUE, "font1", 60, 1245, 200, option_to_screen());
+        draw_text(std::to_string(game.player1.score), COLOR_RED, "font1", 60, 5, 200, option_to_screen());
+        draw_text(std::to_string(game.player2.score), COLOR_BLUE, "font1", 60, 1245, 200, option_to_screen());
     }
 }
 
@@ -328,9 +328,9 @@ void draw_game(game_data &game)
         // Draw the player names and scores
         draw_text("Player 1", COLOR_RED, "font2", 40, 100, 0, option_to_screen());
         draw_text("Player 2", COLOR_BLUE, "font2", 40, 880, 0, option_to_screen());
-        draw_text(to_string(game.player1.score), COLOR_RED, "font1", 60, 5, 200, option_to_screen());
-        draw_text(to_string(game.player2.score), COLOR_BLUE, "font1", 60, 1245, 200, option_to_screen());
-        draw_text("Score " + to_string(GAME_FINISH_SCORE) + " to win", COLOR_YELLOW, "font2", 30, 480, 680, option_to_screen());
+        draw_text(std::to_string(game.player1.score), COLOR_RED, "font1", 60, 5, 200, option_to_screen());
+        draw_text(std::to_string(game.player2.score), COLOR_BLUE, "font1", 60, 1245, 200, option_to_screen());
+        draw_text("Score " + std::to_string(GAME_FINISH_SCORE) + " to win", COLOR_YELLOW, "font2", 30, 480, 680, option_to_screen());
         if (key_down(ESCAPE_KEY))
         {
             game.player1.score = 3;

--- a/games/car-race/game.cpp
+++ b/games/car-race/game.cpp
@@ -325,7 +325,7 @@ void draw_game(game_data &game)
         draw_sprite(game.finish_line);
     }
 
-    draw_text(to_string((int)game.score), COLOR_WHITE, "digi", 50, 650, 10, option_to_screen());
+    draw_text(std::to_string((int)game.score), COLOR_WHITE, "digi", 50, 650, 10, option_to_screen());
     draw_car(game.car);
     if (game.twoPlayer)
     {

--- a/games/car-race/program.cpp
+++ b/games/car-race/program.cpp
@@ -95,7 +95,7 @@ int main()
         {
             stop_sound_effect("carmotor");
             draw_bitmap("ending", 0, 0, option_to_screen());
-            draw_text("Score: " + to_string((int)game.score), COLOR_WHITE, "digi", 70, 100, 400, option_to_screen());
+            draw_text("Score: " + std::to_string((int)game.score), COLOR_WHITE, "digi", 70, 100, 400, option_to_screen());
             if (key_typed(RETURN_KEY))
             {
                 game = new_game();


### PR DESCRIPTION
Replace center_point() with point_at() in BelowTheSurface (API removed from SplashKit). Replace to_string() with std::to_string() in HomemadePong, Pingpong, car-race. DLL files excluded.